### PR TITLE
Update yandex_money.php

### DIFF
--- a/admin/model/extension/payment/yandex_money.php
+++ b/admin/model/extension/payment/yandex_money.php
@@ -761,6 +761,7 @@ class ModelExtensionPaymentYandexMoney extends Model
             $this->load->model('localisation/stock_status');
             $this->load->model('localisation/tax_class');
             $this->load->model('catalog/category');
+            $this->load->model('catalog/option');
             $this->load->language('catalog/product');
             $this->market = new YandexMoneyMarketModel($this->config, $this->db, $this->language,
                 $this->model_localisation_stock_status,


### PR DESCRIPTION
если в функции getMarket() не подключается модель $this->load->model('catalog/option');. Тогда выскакивает ошибка:
Fatal error: Uncaught Error: Call to a member function getOptions() on null in /home/folder/folder/folder/public_html/admin/model/extension/payment/yandex_money/YandexMoneyMarketModel.php:837 Stack trace: #0 /home/folder/folder/folder/public_html/admin/model/extension/payment/yandex_money/YandexMoneyMarketModel.php(811): YandexMoneyMarketModel->htmlOptionSelect('color') #1 /home/folder/folder/folder/public_html/admin/model/extension/payment/yandex_money/YandexMoneyMarketModel.php(798): YandexMoneyMarketModel->htmlOptionItem('color') #2 /home/folder/folder/folder/public_html/system/library/template/Twig/Template.php(604): YandexMoneyMarketModel->htmlOptionList() #3 /home/folder/folder/folder/public_html/storage/cache/c3/c387e2d81438fda103feea88e79d37258b44302ac4df56dac8d8e9d4e9e64146.php(405): Twig_Template->getAttribute(Object(YandexMoneyMarketModel), 'htmlOptionList', Array, 'method') #4 /home/folder/folder/folder/public_html/system/library/template/Twig/Template.php(387): __TwigTemplate_ca1e6534155d69862deb6500914 in /home/folder/folder/folder/public_html/admin/model/extension/payment/yandex_money/YandexMoneyMarketModel.php on line 837